### PR TITLE
fixed setuptools issue

### DIFF
--- a/docker-imposm3/Dockerfile
+++ b/docker-imposm3/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.10
 MAINTAINER Etienne Trimaille <etienne.trimaille@gmail.com>
 
 RUN apt update && apt install -y python3-pip \
+      #Setuptools python package added
+      python3-setuptools \ 
       libprotobuf-dev libleveldb-dev libgeos-dev \
       libpq-dev python3-dev postgresql-client-9.6 python-setuptools \
       --no-install-recommends


### PR DESCRIPTION
Updated dockerfile
`RUN apt update && apt install -y python3-pip \
      #Setuptools python package added
      python3-setuptools \ 
      libprotobuf-dev libleveldb-dev libgeos-dev \
      libpq-dev python3-dev postgresql-client-9.6 python-setuptools \
      --no-install-recommends`