### PR TITLE
Code maintenance

### DIFF
--- a/docker-imposm3/Dockerfile
+++ b/docker-imposm3/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.23-bookworm AS mother
-LABEL maintainer="Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>"
+LABEL maintainer="GeoSolutions <info@geosolutionsgroup.com>"
 
 WORKDIR /code
 #Install the tool for merging the PBF files.
@@ -10,7 +10,7 @@ RUN osmium merge *.pbf -o /code/region/region-latest.osm.pbf
 
 # Final Image.
 FROM golang:1.23-bookworm
-LABEL maintainer="Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>"
+LABEL maintainer="GeoSolutions <info@geosolutionsgroup.com>"
 
 RUN apt update && apt install -y python3-pip \
     #Setuptools python package added

--- a/docker-imposm3/Dockerfile
+++ b/docker-imposm3/Dockerfile
@@ -13,11 +13,11 @@ FROM golang:1.23-bookworm
 LABEL maintainer="Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>"
 
 RUN apt update && apt install -y python3-pip \
-      #Setuptools python package added
-      python3-setuptools \ 
-      libprotobuf-dev libleveldb-dev libgeos-dev \
-      libpq-dev python3-dev postgresql-client-11 python-setuptools \
-      --no-install-recommends
+    #Setuptools python package added
+    python3-setuptools \
+    libprotobuf-dev libleveldb-dev libgeos-dev \
+    libpq-dev python3-dev postgresql-client python3-setuptools \
+    --no-install-recommends
 
 RUN ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so
 

--- a/docker-imposm3/Dockerfile
+++ b/docker-imposm3/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.16.0-buster as mother
-MAINTAINER Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>
+FROM golang:1.23-bookworm AS mother
+LABEL maintainer="Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>"
 
 WORKDIR /code
 #Install the tool for merging the PBF files.
@@ -9,8 +9,8 @@ COPY ./*.pbf /code/
 RUN osmium merge *.pbf -o /code/region/region-latest.osm.pbf
 
 # Final Image.
-FROM golang:1.16.0-buster
-MAINTAINER Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>
+FROM golang:1.23-bookworm
+LABEL maintainer="Asdrubal Gonzalez <asdrubal.gonzalez@geo-solutions.it>"
 
 RUN apt update && apt install -y python3-pip \
       #Setuptools python package added
@@ -22,7 +22,7 @@ RUN apt update && apt install -y python3-pip \
 RUN ln -s /usr/lib/libgeos_c.so /usr/lib/libgeos.so
 
 WORKDIR $GOPATH
-RUN go get github.com/tools/godep
+RUN go install github.com/tools/godep@latest
 RUN git clone https://github.com/omniscale/imposm3 src/github.com/omniscale/imposm3
 RUN cd src/github.com/omniscale/imposm3 && make update_version && go install ./cmd/imposm/
 

--- a/docker-imposm3/Dockerfile
+++ b/docker-imposm3/Dockerfile
@@ -28,7 +28,8 @@ RUN cd src/github.com/omniscale/imposm3 && make update_version && go install ./c
 
 # Preparing everything for the importer.
 ADD requirements.txt /home/requirements.txt
-RUN pip3 install -r /home/requirements.txt
+# RUN pip3 install -r /home/requirements.txt
+RUN apt install python3-psycopg2
 ADD importer.py /home/
 
 # Add YAML Mapping file

--- a/docker-imposm3/requirements.txt
+++ b/docker-imposm3/requirements.txt
@@ -1,1 +1,2 @@
-psycopg2-binary
+# Now installed with system package manager.
+# psycopg2-binary

--- a/docker-osmupdate/Dockerfile
+++ b/docker-osmupdate/Dockerfile
@@ -1,6 +1,6 @@
 #--------- Generic stuff all our Dockerfiles should start with so we get caching ------------
 FROM ubuntu:18.04
-MAINTAINER Etienne Trimaille<etienne.trimaille@gmail.com>
+LABEL maintainer="Etienne Trimaille<etienne.trimaille@gmail.com>"
 
 RUN  export DEBIAN_FRONTEND=noninteractive
 ENV  DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
- The Debian package manager is now used to install psycopg2. Installing with pip fails due to the new policy regarding "externally manager" packages (PEP 668)
- Use latest Go (1.23)
- Code formatting